### PR TITLE
chore: exclude netlify from e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   e2e-test:
     strategy:
       matrix:
-        provider: [vercel, netlify, cloudflare, local]
+        provider: [vercel, cloudflare, local]
     uses: jill64/playwright-config/.github/workflows/run-playwright.yml@732a5e76b8177046ae89a3a216ca21ec21b28897 # v2.1.0
     with:
       test-command: npx playwright test

--- a/README.md
+++ b/README.md
@@ -14,14 +14,12 @@
 npm i @jill64/sentry-sveltekit-edge
 ```
 
+## Requirements
+
+- Any edge runtime that supports `fetch`
+
 > [!NOTE]
 > If running on `Cloudflare Pages`, use instead [`@jill64/sentry-sveltekit-cloudflare`](https://github.com/jill64/sentry-sveltekit-cloudflare).
-
-## Confirmed Adapters
-
-- adapter-vercel
-- adapter-netlify
-- adapter-cloudflare
 
 ## Limitations
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined CI providers by removing Netlify from the list.

- **Documentation**
  - Updated installation instructions and requirements to reflect support for any edge runtime with `fetch`.
  - Removed specific notes about Cloudflare Pages, simplifying the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->